### PR TITLE
tween compiler error fixes

### DIFF
--- a/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/TweenTestBed.cs
+++ b/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/TweenTestBed.cs
@@ -21,9 +21,7 @@ namespace com.tinylabproductions.TLPLib.Tween.fun_tween {
     public float duration = 5;
     public List<Vector3> nodes;
     public List<Vector2> nodes2;
-
-
-    TweenManager manager;
+    public TweenManager manager;
 
     public void Start() {
       List<Vector3> positionArray = new List<Vector3>();

--- a/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/path/Vector3PathBehaviour.cs
+++ b/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/path/Vector3PathBehaviour.cs
@@ -5,12 +5,18 @@ using UnityEngine;
 
 namespace com.tinylabproductions.TLPLib.Tween.fun_tween.path {
   public partial class Vector3PathBehaviour : MonoBehaviour {
+
+    #region Unity Serialized Fields
 #pragma warning disable 649
+    // ReSharper disable FieldCanBeMadeReadOnly.Local
     [SerializeField] bool _relative, _closed;
     [SerializeField, Range(50, 1000)] int pathResolution = 250;
     [SerializeField] Vector3Path.InterpolationMethod _method;
     [SerializeField] List<Vector3> _nodes = new List<Vector3>();
+    // ReSharper restore FieldCanBeMadeReadOnly.Local
 #pragma warning restore 649
+    #endregion
+
     Vector3Path _path;
     
     public void invalidate() => _path = null;

--- a/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/path/Vector3PathBehaviour.cs
+++ b/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/path/Vector3PathBehaviour.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using com.tinylabproductions.TLPLib.Functional;
-using JetBrains.Annotations;
 using UnityEngine;
 
 namespace com.tinylabproductions.TLPLib.Tween.fun_tween.path {

--- a/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/path/Vector3PathBehaviour.cs
+++ b/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/path/Vector3PathBehaviour.cs
@@ -1,16 +1,17 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using com.tinylabproductions.TLPLib.Functional;
+using JetBrains.Annotations;
 using UnityEngine;
 
 namespace com.tinylabproductions.TLPLib.Tween.fun_tween.path {
   public partial class Vector3PathBehaviour : MonoBehaviour {
-    
+#pragma warning disable 649
     [SerializeField] bool _relative, _closed;
     [SerializeField, Range(50, 1000)] int pathResolution = 250;
     [SerializeField] Vector3Path.InterpolationMethod _method;
     [SerializeField] List<Vector3> _nodes = new List<Vector3>();
-
+#pragma warning restore 649
     Vector3Path _path;
     
     public void invalidate() => _path = null;

--- a/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/serialization/manager/FunTweenManager.cs
+++ b/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/serialization/manager/FunTweenManager.cs
@@ -27,7 +27,10 @@ namespace com.tinylabproductions.TLPLib.Tween.fun_tween.serialization.manager {
     uint currentIteration => _manager == null ? 0 : _manager.currentIteration;
     [Inspect, Tab(Tab.Actions), UsedImplicitly, ReadOnly]
     float timescale => _manager == null ? -1 : _manager.timescale;
-#pragma warning disable 0649
+
+    #region Unity Serialized Fields
+#pragma warning disable 649
+    // ReSharper disable FieldCanBeMadeReadOnly.Local
     [
       SerializeField, Tab(Tab.Fields),
       Help(
@@ -53,8 +56,10 @@ namespace com.tinylabproductions.TLPLib.Tween.fun_tween.serialization.manager {
     [SerializeField, Tab(Tab.Fields)] TweenManager.Loop _looping = new TweenManager.Loop(1, TweenManager.Loop.Mode.Normal);
     [SerializeField, NotNull, Tab(Tab.Fields)] SerializedTweenTimeline _timeline;
     [SerializeField, NotNull, CreateDerived, Tab(Tab.Fields)] SerializedTweenCallback[] _onStart, _onEnd;
+    // ReSharper restore FieldCanBeMadeReadOnly.Local
 #pragma warning restore 649
-    
+    #endregion
+
     TweenManager _manager;
 
     [PublicAPI]

--- a/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/serialization/manager/FunTweenManager.cs
+++ b/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/serialization/manager/FunTweenManager.cs
@@ -27,7 +27,6 @@ namespace com.tinylabproductions.TLPLib.Tween.fun_tween.serialization.manager {
     uint currentIteration => _manager == null ? 0 : _manager.currentIteration;
     [Inspect, Tab(Tab.Actions), UsedImplicitly, ReadOnly]
     float timescale => _manager == null ? -1 : _manager.timescale;
-    
 #pragma warning disable 0649
     [
       SerializeField, Tab(Tab.Fields),
@@ -57,7 +56,6 @@ namespace com.tinylabproductions.TLPLib.Tween.fun_tween.serialization.manager {
 #pragma warning restore 649
     
     TweenManager _manager;
-    
 
     [PublicAPI]
     public TweenManager manager {

--- a/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/serialization/manager/FunTweenManager.cs
+++ b/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/serialization/manager/FunTweenManager.cs
@@ -28,6 +28,7 @@ namespace com.tinylabproductions.TLPLib.Tween.fun_tween.serialization.manager {
     [Inspect, Tab(Tab.Actions), UsedImplicitly, ReadOnly]
     float timescale => _manager == null ? -1 : _manager.timescale;
     
+#pragma warning disable 0649
     [
       SerializeField, Tab(Tab.Fields),
       Help(
@@ -53,8 +54,10 @@ namespace com.tinylabproductions.TLPLib.Tween.fun_tween.serialization.manager {
     [SerializeField, Tab(Tab.Fields)] TweenManager.Loop _looping = new TweenManager.Loop(1, TweenManager.Loop.Mode.Normal);
     [SerializeField, NotNull, Tab(Tab.Fields)] SerializedTweenTimeline _timeline;
     [SerializeField, NotNull, CreateDerived, Tab(Tab.Fields)] SerializedTweenCallback[] _onStart, _onEnd;
-
+#pragma warning restore 649
+    
     TweenManager _manager;
+    
 
     [PublicAPI]
     public TweenManager manager {

--- a/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/serialization/timelines/FunTweenTimeline.cs
+++ b/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/serialization/timelines/FunTweenTimeline.cs
@@ -7,8 +7,9 @@ namespace com.tinylabproductions.TLPLib.Tween.fun_tween.serialization.sequences 
   /// <see cref="TweenTimeline"/> as a <see cref="MonoBehaviour"/>.
   /// </summary>
   public partial class FunTweenTimeline : MonoBehaviour, Invalidatable {
+#pragma warning disable 649
     [SerializeField, PublicAccessor, NotNull] SerializedTweenTimeline _timeline;
-    
+#pragma warning restore 649
     public void invalidate() => _timeline.invalidate();
   }
 }

--- a/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/serialization/timelines/FunTweenTimeline.cs
+++ b/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/serialization/timelines/FunTweenTimeline.cs
@@ -7,9 +7,15 @@ namespace com.tinylabproductions.TLPLib.Tween.fun_tween.serialization.sequences 
   /// <see cref="TweenTimeline"/> as a <see cref="MonoBehaviour"/>.
   /// </summary>
   public partial class FunTweenTimeline : MonoBehaviour, Invalidatable {
+
+    #region Unity Serialized Fields
 #pragma warning disable 649
+    // ReSharper disable FieldCanBeMadeReadOnly.Local
     [SerializeField, PublicAccessor, NotNull] SerializedTweenTimeline _timeline;
+    // ReSharper restore FieldCanBeMadeReadOnly.Local
 #pragma warning restore 649
+    #endregion
+
     public void invalidate() => _timeline.invalidate();
   }
 }

--- a/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/serialization/timelines/TimelineReference.cs
+++ b/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/serialization/timelines/TimelineReference.cs
@@ -11,8 +11,9 @@ namespace com.tinylabproductions.TLPLib.Tween.fun_tween.serialization.sequences 
   /// </summary>
   [AddComponentMenu("")]
   public partial class TimelineReference : SerializedTweenTimelineElement {
+#pragma warning disable 649
     [SerializeField, PublicAccessor, NotNull] FunTweenTimeline _timeline;
-
+#pragma warning restore 649
     IEnumerable<TweenTimelineElement> _elements;
 
     public override float duration => _timeline.timeline.timeline.duration;

--- a/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/serialization/timelines/TimelineReference.cs
+++ b/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/serialization/timelines/TimelineReference.cs
@@ -11,9 +11,13 @@ namespace com.tinylabproductions.TLPLib.Tween.fun_tween.serialization.sequences 
   /// </summary>
   [AddComponentMenu("")]
   public partial class TimelineReference : SerializedTweenTimelineElement {
+    #region Unity Serialized Fields
 #pragma warning disable 649
+    // ReSharper disable FieldCanBeMadeReadOnly.Local
     [SerializeField, PublicAccessor, NotNull] FunTweenTimeline _timeline;
+    // ReSharper restore FieldCanBeMadeReadOnly.Local
 #pragma warning restore 649
+    #endregion
     IEnumerable<TweenTimelineElement> _elements;
 
     public override float duration => _timeline.timeline.timeline.duration;

--- a/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/serialization/tween_callbacks/Callback_UnityEvent.cs
+++ b/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/serialization/tween_callbacks/Callback_UnityEvent.cs
@@ -5,12 +5,10 @@ using UnityEngine.Events;
 namespace com.tinylabproductions.TLPLib.Tween.fun_tween.serialization.tween_callbacks {
   [AddComponentMenu("")]
   public class Callback_UnityEvent : SerializedTweenCallback {
-    
 #pragma warning disable 649
     [SerializeField] InvokeOn _invokeOn;
     [SerializeField, NotNull] UnityEvent _onEvent;
 #pragma warning restore 649
-    
     protected override TweenCallback createCallback() => 
       new TweenCallback(evt => {
         if (shouldInvoke(_invokeOn, evt)) _onEvent.Invoke();

--- a/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/serialization/tween_callbacks/Callback_UnityEvent.cs
+++ b/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/serialization/tween_callbacks/Callback_UnityEvent.cs
@@ -5,9 +5,12 @@ using UnityEngine.Events;
 namespace com.tinylabproductions.TLPLib.Tween.fun_tween.serialization.tween_callbacks {
   [AddComponentMenu("")]
   public class Callback_UnityEvent : SerializedTweenCallback {
+    
+#pragma warning disable 649
     [SerializeField] InvokeOn _invokeOn;
     [SerializeField, NotNull] UnityEvent _onEvent;
-
+#pragma warning restore 649
+    
     protected override TweenCallback createCallback() => 
       new TweenCallback(evt => {
         if (shouldInvoke(_invokeOn, evt)) _onEvent.Invoke();

--- a/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/serialization/tween_callbacks/Callback_UnityEvent.cs
+++ b/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/serialization/tween_callbacks/Callback_UnityEvent.cs
@@ -5,10 +5,16 @@ using UnityEngine.Events;
 namespace com.tinylabproductions.TLPLib.Tween.fun_tween.serialization.tween_callbacks {
   [AddComponentMenu("")]
   public class Callback_UnityEvent : SerializedTweenCallback {
+
+    #region Unity Serialized Fields
 #pragma warning disable 649
+    // ReSharper disable FieldCanBeMadeReadOnly.Local
     [SerializeField] InvokeOn _invokeOn;
     [SerializeField, NotNull] UnityEvent _onEvent;
+    // ReSharper restore FieldCanBeMadeReadOnly.Local
 #pragma warning restore 649
+    #endregion
+
     protected override TweenCallback createCallback() => 
       new TweenCallback(evt => {
         if (shouldInvoke(_invokeOn, evt)) _onEvent.Invoke();

--- a/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/serialization/tweeners/Path_Transfrom_Position.cs
+++ b/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/serialization/tweeners/Path_Transfrom_Position.cs
@@ -5,9 +5,13 @@ using UnityEngine;
 namespace com.tinylabproductions.TLPLib.Tween.fun_tween.serialization.tweeners {
   [AddComponentMenu("")]
   public class Path_Transfrom_Position : SerializedTweener<float, float, Transform> {
+    #region Unity Serialized Fields
 #pragma warning disable 649
+    // ReSharper disable FieldCanBeMadeReadOnly.Local
     [SerializeField, NotNull] Vector3PathBehaviour pathBehaviour;
+    // ReSharper restore FieldCanBeMadeReadOnly.Local
 #pragma warning restore 649
+    #endregion
     public Path_Transfrom_Position() : base(
       TweenOps.float_, SerializedTweenerOps.Add.float_,
       // Paths do not have current state, so their current state is 0.

--- a/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/serialization/tweeners/Path_Transfrom_Position.cs
+++ b/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/serialization/tweeners/Path_Transfrom_Position.cs
@@ -5,8 +5,9 @@ using UnityEngine;
 namespace com.tinylabproductions.TLPLib.Tween.fun_tween.serialization.tweeners {
   [AddComponentMenu("")]
   public class Path_Transfrom_Position : SerializedTweener<float, float, Transform> {
+#pragma warning disable 649
     [SerializeField, NotNull] Vector3PathBehaviour pathBehaviour;
-
+#pragma warning restore 649
     public Path_Transfrom_Position() : base(
       TweenOps.float_, SerializedTweenerOps.Add.float_,
       // Paths do not have current state, so their current state is 0.

--- a/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/serialization/tweeners/SerializedTweener.cs
+++ b/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/serialization/tweeners/SerializedTweener.cs
@@ -14,7 +14,6 @@ namespace com.tinylabproductions.TLPLib.Tween.fun_tween.serialization.tweeners {
   }
 
   public abstract class SerializedTweener<SourceType, DestinationType, Target> : SerializedTweener {
-    
 #pragma warning disable 649
     [SerializeField, FormerlySerializedAs("_isRelative")] Mode _mode = Mode.RelativeFromCreation;
     [SerializeField, NotNull] SourceType _start, _end;

--- a/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/serialization/tweeners/SerializedTweener.cs
+++ b/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/serialization/tweeners/SerializedTweener.cs
@@ -14,13 +14,18 @@ namespace com.tinylabproductions.TLPLib.Tween.fun_tween.serialization.tweeners {
   }
 
   public abstract class SerializedTweener<SourceType, DestinationType, Target> : SerializedTweener {
+
+    #region Unity Serialized Fields
 #pragma warning disable 649
+    // ReSharper disable FieldCanBeMadeReadOnly.Local
     [SerializeField, FormerlySerializedAs("_isRelative")] Mode _mode = Mode.RelativeFromCreation;
     [SerializeField, NotNull] SourceType _start, _end;
     [SerializeField, Tooltip("in seconds")] float _duration = 1;
     [SerializeField, NotNull] SerializedEase _ease;
     [SerializeField, NotNull, NonEmpty] Target[] _targets = new Target[1];
+    // ReSharper restore FieldCanBeMadeReadOnly.Local
 #pragma warning restore 649
+    #endregion
     
     readonly Tween<DestinationType>.Ops ops;
     readonly SerializedTweenerOps.Add<DestinationType> add;

--- a/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/serialization/tweeners/SerializedTweener.cs
+++ b/parts/0000-TLPLib/Assets/Plugins/Vendor/TLPLib/Tween/fun_tween/serialization/tweeners/SerializedTweener.cs
@@ -15,12 +15,14 @@ namespace com.tinylabproductions.TLPLib.Tween.fun_tween.serialization.tweeners {
 
   public abstract class SerializedTweener<SourceType, DestinationType, Target> : SerializedTweener {
     
+#pragma warning disable 649
     [SerializeField, FormerlySerializedAs("_isRelative")] Mode _mode = Mode.RelativeFromCreation;
     [SerializeField, NotNull] SourceType _start, _end;
     [SerializeField, Tooltip("in seconds")] float _duration = 1;
     [SerializeField, NotNull] SerializedEase _ease;
     [SerializeField, NotNull, NonEmpty] Target[] _targets = new Target[1];
-
+#pragma warning restore 649
+    
     readonly Tween<DestinationType>.Ops ops;
     readonly SerializedTweenerOps.Add<DestinationType> add;
     readonly SerializedTweenerOps.Extract<DestinationType, Target> extract;


### PR DESCRIPTION
Errors were shown because compiler doesn't know that we are setting private fields via inspector

-Added #pragma warning disable where needed
-TweenTestBed manager field made public